### PR TITLE
fixed turtle sytax for dct:creator

### DIFF
--- a/vsso.ttl
+++ b/vsso.ttl
@@ -20,7 +20,7 @@ vsso: rdf:type owl:Ontology ;
   dct:license <http://creativecommons.org/licenses/by/4.0/> ;
   dct:modified "2020-06-23"^^xsd:date ;
   dct:created "2018-01-10"^^xsd:date ;
-  dct:creator Benjamin Klotz, Raphael Troncy, Daniel Wilms ;
+  dct:creator "Benjamin Klotz", "Raphael Troncy", "Daniel Wilms" ;
   owl:versionInfo """v1.0 23/06/2020"""@en ;
   vann:preferredNamespacePrefix "vsso" .
 


### PR DESCRIPTION
Ontology cannot be loaded with OWL API/Protege since the literals for dct:creator are not quoted